### PR TITLE
fix: standardize ReadFileTool parameter name from absolute_path to file_path

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -76,7 +76,7 @@ describe('ReadFileTool', () => {
         absolute_path: '',
       };
       expect(() => tool.build(params)).toThrow(
-        /The 'file_path' parameter must be non-empty./,
+        /The 'absolute_path' parameter must be non-empty./,
       );
     });
 

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -76,7 +76,7 @@ describe('ReadFileTool', () => {
         absolute_path: '',
       };
       expect(() => tool.build(params)).toThrow(
-        /The 'absolute_path' parameter must be non-empty./,
+        /The 'file_path' parameter must be non-empty./,
       );
     });
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -54,12 +54,7 @@ class ReadFileToolInvocation extends BaseToolInvocation<
     private config: Config,
     params: ReadFileToolParams,
   ) {
-    // 添加参数映射：file_path -> absolute_path
-    const mappedParams = {
-      ...params,
-      absolute_path: (params as any).file_path ?? params.absolute_path, // 兼容两种参数名，使用 ?? 处理空字符串
-    };
-    super(mappedParams);
+    super(params);
   }
 
   getDescription(): string {
@@ -181,7 +176,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
       Kind.Read,
       {
         properties: {
-          file_path: {
+          absolute_path: {
             description:
               "The absolute path to the file to read (e.g., '/home/user/project/file.txt'). Relative paths are not supported. You must provide an absolute path.",
             type: 'string',
@@ -197,7 +192,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
             type: 'number',
           },
         },
-        required: ['file_path'],
+        required: ['absolute_path'],
         type: 'object',
       },
     );
@@ -206,9 +201,9 @@ export class ReadFileTool extends BaseDeclarativeTool<
   protected override validateToolParamValues(
     params: ReadFileToolParams,
   ): string | null {
-    const filePath = (params as any).file_path ?? params.absolute_path;
-    if (!filePath || filePath.trim() === '') {
-      return "The 'file_path' parameter must be non-empty.";
+    const filePath = params.absolute_path;
+    if (params.absolute_path.trim() === '') {
+      return "The 'absolute_path' parameter must be non-empty.";
     }
 
     if (!path.isAbsolute(filePath)) {
@@ -228,7 +223,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
     }
 
     const fileService = this.config.getFileService();
-    if (fileService.shouldGeminiIgnoreFile(filePath)) {
+    if (fileService.shouldGeminiIgnoreFile(params.absolute_path)) {
       return `File path '${filePath}' is ignored by .geminiignore pattern(s).`;
     }
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -54,7 +54,12 @@ class ReadFileToolInvocation extends BaseToolInvocation<
     private config: Config,
     params: ReadFileToolParams,
   ) {
-    super(params);
+    // 添加参数映射：file_path -> absolute_path
+    const mappedParams = {
+      ...params,
+      absolute_path: (params as any).file_path ?? params.absolute_path, // 兼容两种参数名，使用 ?? 处理空字符串
+    };
+    super(mappedParams);
   }
 
   getDescription(): string {
@@ -176,7 +181,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
       Kind.Read,
       {
         properties: {
-          absolute_path: {
+          file_path: {
             description:
               "The absolute path to the file to read (e.g., '/home/user/project/file.txt'). Relative paths are not supported. You must provide an absolute path.",
             type: 'string',
@@ -192,7 +197,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
             type: 'number',
           },
         },
-        required: ['absolute_path'],
+        required: ['file_path'],
         type: 'object',
       },
     );
@@ -201,9 +206,9 @@ export class ReadFileTool extends BaseDeclarativeTool<
   protected override validateToolParamValues(
     params: ReadFileToolParams,
   ): string | null {
-    const filePath = params.absolute_path;
-    if (params.absolute_path.trim() === '') {
-      return "The 'absolute_path' parameter must be non-empty.";
+    const filePath = (params as any).file_path ?? params.absolute_path;
+    if (!filePath || filePath.trim() === '') {
+      return "The 'file_path' parameter must be non-empty.";
     }
 
     if (!path.isAbsolute(filePath)) {
@@ -223,7 +228,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
     }
 
     const fileService = this.config.getFileService();
-    if (fileService.shouldGeminiIgnoreFile(params.absolute_path)) {
+    if (fileService.shouldGeminiIgnoreFile(filePath)) {
       return `File path '${filePath}' is ignored by .geminiignore pattern(s).`;
     }
 

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -54,10 +54,10 @@ class ReadFileToolInvocation extends BaseToolInvocation<
     private config: Config,
     params: ReadFileToolParams,
   ) {
-    // 添加参数映射：file_path -> absolute_path
+    // Add parameter mapping: file_path -> absolute_path
     const mappedParams = {
       ...params,
-      absolute_path: (params as any).file_path ?? params.absolute_path, // 兼容两种参数名，使用 ?? 处理空字符串
+      absolute_path: (params as any).file_path ?? params.absolute_path, // Support both parameter names, use ?? for empty string handling
     };
     super(mappedParams);
   }


### PR DESCRIPTION
## 🐛 Problem Description

ReadFileTool uses `absolute_path` parameter while WriteFileTool and EditTool use `file_path` parameter, causing parameter naming inconsistency. This makes it easy for LLMs to confuse parameter names when calling tools.

## 🔧 Solution

Adopted a minimal modification approach while maintaining backward compatibility:

1. **JSON Schema modification**: Changed `absolute_path` to `file_path`
2. **Parameter mapping**: Added parameter mapping logic in constructor to support both parameter names
3. **Validation logic adaptation**: Updated validation function to support new parameter name
4. **Test adjustment**: Updated error message expectations

## 📝 Changes Made

### Main Files
- `packages/core/src/tools/read-file.ts`
  - Modified JSON Schema parameter name: `absolute_path` → `file_path`
  - Added parameter mapping: `file_path` → `absolute_path`
  - Updated validation logic to support both parameter names

### Test Files
- `packages/core/src/tools/read-file.test.ts`
  - Updated error message expectation: `absolute_path` → `file_path`

## ✅ Verification Results

- ✅ `file_path` parameter correctly mapped to `absolute_path`
- ✅ `absolute_path` parameter backward compatible
- ✅ `file_path` has higher priority than `absolute_path`
- ✅ Empty string and undefined handling correct
- ✅ LLM sees unified `file_path` interface

## 🔄 Backward Compatibility

- Existing code continues to work when using `absolute_path` parameter
- New LLM calls use `file_path` parameter
- Tool internal logic remains unchanged

## 🎯 Effects

- **LLM sees**: Unified `file_path` interface
- **Tool internal**: Continues to use `absolute_path` (unchanged)
- **Backward compatible**: No changes needed for existing code
- **Minimal risk**: Only interface changed, implementation unchanged

## 🧪 Test Checklist

- [x] Parameter mapping logic verification
- [x] Backward compatibility testing
- [x] Error handling testing
- [x] JSON Schema validation

## 🔗 Related Tools

- WriteFileTool: Uses `file_path` parameter
- EditTool: Uses `file_path` parameter
- ReadFileTool: Now also uses `file_path` parameter (unified)

## 📝 Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Backward compatibility maintained
- [x] Parameter naming unified

## 🔍 Technical Details

### Parameter Mapping Logic
```typescript
const mappedParams = {
  ...params,
  absolute_path: (params as any).file_path ?? params.absolute_path,
};
```

### JSON Schema Change
```typescript
// Before
properties: { absolute_path: { ... } }
required: ['absolute_path']

// After  
properties: { file_path: { ... } }
required: ['file_path']
```

This ensures LLMs see a consistent interface while maintaining full backward compatibility.