### PR TITLE
fix(openaiContentGenerator): use parametersJsonSchema fallback for tool declarations

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -962,8 +962,9 @@ export class OpenAIContentGenerator implements ContentGenerator {
               function: {
                 name: func.name,
                 description: func.description,
+                // Support both Gemini-native `parameters` and core `parametersJsonSchema` (from zodToJsonSchema)
                 parameters: this.convertGeminiParametersToOpenAI(
-                  (func.parameters || {}) as Record<string, unknown>,
+                  (func.parameters || func.parametersJsonSchema || {}) as Record<string, unknown>,
                 ),
               },
             });


### PR DESCRIPTION
## Summary

- Fix empty tool call parameters when using OpenAI-compatible models (e.g. gpt-5.4) via newapi protocol
- Bump version to 0.30.2

## Changes

- **`openaiContentGenerator.ts`**: `convertGeminiToolsToOpenAI()` now falls back to `func.parametersJsonSchema` when `func.parameters` is undefined. aioncli-core tool declarations use `parametersJsonSchema` (from `zodToJsonSchema`), but the OpenAI conversion only read `parameters`, producing empty schemas for all tools.
- **`package.json`**: Version bump 0.30.1 → 0.30.2

## Root Cause

`convertGeminiToolsToOpenAI()` reads `func.parameters` to build OpenAI tool schema, but core tool declarations store the schema in `parametersJsonSchema`. The empty schema `{ type: 'object', properties: {} }` caused OpenAI-compatible models to strictly return `{}` for all tool calls.

## Test Plan

- [ ] Create a session with newapi protocol and gpt-5.4 model
- [ ] Trigger a tool call (e.g. activate_skill)
- [ ] Verify tool call parameters are correctly populated (not empty `{}`)
- [ ] Verify Gemini-native models still work correctly (they use `parameters` field)