### PR TITLE
fix(core): ensure mutually exclusive temperature/topP for Bedrock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18848,7 +18848,7 @@
     },
     "packages/core": {
       "name": "@office-ai/aioncli-core",
-      "version": "0.30.2",
+      "version": "0.30.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/core/src/core/bedrockContentGenerator.ts
+++ b/packages/core/src/core/bedrockContentGenerator.ts
@@ -86,6 +86,31 @@ export class BedrockContentGenerator implements ContentGenerator {
     return 'AWS SDK default credential chain';
   }
 
+  /**
+   * Build inference config with mutually exclusive temperature/topP.
+   * Bedrock forbids sending both for Claude models.
+   * When both are present, prefer temperature (more commonly configured).
+   */
+  private buildInferenceConfig(request: GenerateContentParameters): {
+    maxTokens: number;
+    temperature?: number;
+    topP?: number;
+  } {
+    const config: { maxTokens: number; temperature?: number; topP?: number } = {
+      maxTokens: request.config?.maxOutputTokens || 4096,
+    };
+
+    if (request.config?.temperature !== undefined) {
+      config.temperature = request.config.temperature;
+    } else if (request.config?.topP !== undefined) {
+      config.topP = request.config.topP;
+    } else {
+      config.temperature = 1.0;
+    }
+
+    return config;
+  }
+
   async generateContent(
     request: GenerateContentParameters,
     _userPromptId: string,
@@ -109,11 +134,7 @@ export class BedrockContentGenerator implements ContentGenerator {
             messages,
             system,
             toolConfig,
-            inferenceConfig: {
-              maxTokens: request.config?.maxOutputTokens || 4096,
-              temperature: request.config?.temperature ?? 1.0,
-              topP: request.config?.topP,
-            },
+            inferenceConfig: this.buildInferenceConfig(request),
           });
 
           debugLogger.log(
@@ -172,11 +193,7 @@ export class BedrockContentGenerator implements ContentGenerator {
             messages,
             system,
             toolConfig,
-            inferenceConfig: {
-              maxTokens: request.config?.maxOutputTokens || 4096,
-              temperature: request.config?.temperature ?? 1.0,
-              topP: request.config?.topP,
-            },
+            inferenceConfig: this.buildInferenceConfig(request),
           });
 
           debugLogger.log(
@@ -510,7 +527,7 @@ export class BedrockContentGenerator implements ContentGenerator {
             toolUse: {
               toolUseId: fc.id || `tool_${Date.now()}_${Math.random()}`,
               name: fc.name,
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion
               input: fc.args as any, // Bedrock accepts any JSON-serializable value
             },
           });
@@ -601,6 +618,7 @@ export class BedrockContentGenerator implements ContentGenerator {
           functionCall: {
             id: toolUse.toolUseId,
             name: toolUse.name || '',
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
             args: (toolUse.input as Record<string, unknown>) || {},
           },
         });


### PR DESCRIPTION
## Summary

- AWS Bedrock Claude models reject requests when both `temperature` and `topP` are specified in `inferenceConfig`
- Previously, `temperature` always defaulted to `1.0` (via `??`) while `topP` was passed through from model config (default `1`), causing a `ValidationException`
- Extract `buildInferenceConfig()` private method to apply mutual exclusion: prefer `temperature` when both are present, fall back to `topP` when only that is set, default to `temperature=1.0` when neither is provided

## Test plan

- [x] Verified with AionUI using AWS Bedrock `global.anthropic.claude-opus-4-6-v1` — error resolved
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Build succeeds (`npm run build`)