### PR TITLE
chore: bump version to 0.30.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18848,7 +18848,7 @@
     },
     "packages/core": {
       "name": "@office-ai/aioncli-core",
-      "version": "0.30.4",
+      "version": "0.30.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.8",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@office-ai/aioncli-core",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "Gemini CLI Core",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump core package version to 0.30.5

## Changes
- `packages/core/package.json`: version 0.30.4 → 0.30.5
- `package-lock.json`: lockfile sync