### PR TITLE
fix(core): handle functionCall/functionResponse mismatch when id is absent

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -711,13 +711,17 @@ export class GeminiChat {
    * functionResponse parts exactly matches the number of functionCall parts.
    *
    * Two-pass approach:
-   *  1. Deduplicate functionResponse parts (keep only the first occurrence per id).
+   *  1. Deduplicate functionResponse parts (keep only the first occurrence per
+   *     id, or per name when id is absent).
    *  2. Remove orphaned functionCall parts whose id has no matching
-   *     functionResponse, and vice-versa.
+   *     functionResponse, and vice-versa.  Only parts that carry an explicit
+   *     `id` participate in orphan removal — parts identified solely by `name`
+   *     are left intact because they may represent in-progress tool calls
+   *     awaiting responses.
    */
   private deduplicateFunctionResponses(history: Content[]): Content[] {
     // --- Pass 1: deduplicate functionResponse parts --------------------------
-    const seenResponseIds = new Set<string>();
+    const seenResponseKeys = new Set<string>();
     const deduplicated: Content[] = [];
 
     for (const content of history) {
@@ -727,12 +731,14 @@ export class GeminiChat {
       }
 
       const filteredParts = content.parts.filter((part) => {
-        if ('functionResponse' in part && part.functionResponse?.id) {
-          const id = part.functionResponse.id;
-          if (seenResponseIds.has(id)) {
-            return false;
+        if ('functionResponse' in part && part.functionResponse) {
+          const key = part.functionResponse.id || part.functionResponse.name;
+          if (key) {
+            if (seenResponseKeys.has(key)) {
+              return false;
+            }
+            seenResponseKeys.add(key);
           }
-          seenResponseIds.add(id);
         }
         return true;
       });

--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.test.ts
@@ -443,7 +443,7 @@ describe('NumericalClassifierStrategy', () => {
     expect(consoleWarnSpy).toHaveBeenCalled();
   });
 
-  it('should include tool-related history when sending to classifier', async () => {
+  it('should strip functionCall/functionResponse parts from history sent to classifier', async () => {
     mockContext.history = [
       { role: 'user', parts: [{ text: 'call a tool' }] },
       { role: 'model', parts: [{ functionCall: { name: 'test_tool' } }] },
@@ -469,9 +469,11 @@ describe('NumericalClassifierStrategy', () => {
       .calls[0][0];
     const contents = generateJsonCall.contents;
 
+    // functionCall and functionResponse parts should be stripped;
+    // content entries that become empty after stripping are removed entirely.
     const expectedContents = [
-      ...mockContext.history,
-      // The last user turn is the request part
+      { role: 'user', parts: [{ text: 'call a tool' }] },
+      { role: 'user', parts: [{ text: 'another user turn' }] },
       {
         role: 'user',
         parts: [{ text: 'simple task' }],

--- a/packages/core/src/routing/strategies/numericalClassifierStrategy.ts
+++ b/packages/core/src/routing/strategies/numericalClassifierStrategy.ts
@@ -14,6 +14,7 @@ import type {
 } from '../routingStrategy.js';
 import { resolveClassifierModel, isGemini3Model } from '../../config/models.js';
 import { createUserContent, Type } from '@google/genai';
+import type { Content } from '@google/genai';
 import type { Config } from '../../config/config.js';
 import { debugLogger } from '../../utils/debugLogger.js';
 import { LlmRole } from '../../telemetry/types.js';
@@ -147,7 +148,12 @@ export class NumericalClassifierStrategy implements RoutingStrategy {
 
       const promptId = getPromptIdWithFallback('classifier-router');
 
-      const finalHistory = context.history.slice(-HISTORY_TURNS_FOR_CONTEXT);
+      // The classifier only needs text context for complexity scoring.
+      // Strip functionCall / functionResponse parts to avoid API errors
+      // caused by mismatched call/response counts in the history.
+      const finalHistory = stripFunctionParts(
+        context.history.slice(-HISTORY_TURNS_FOR_CONTEXT),
+      );
 
       // Wrap the user's request in tags to prevent prompt injection
       const requestParts = Array.isArray(context.request)
@@ -242,4 +248,32 @@ export class NumericalClassifierStrategy implements RoutingStrategy {
 
     return { threshold, groupLabel, modelAlias };
   }
+}
+
+/**
+ * Removes functionCall and functionResponse parts from history contents.
+ * Returns only the text-bearing parts so the classifier never sees
+ * mismatched tool call / response counts.
+ */
+function stripFunctionParts(history: Content[]): Content[] {
+  const result: Content[] = [];
+
+  for (const content of history) {
+    if (!content.parts || content.parts.length === 0) {
+      result.push(content);
+      continue;
+    }
+
+    const textParts = content.parts.filter(
+      (part) =>
+        !('functionCall' in part && part.functionCall) &&
+        !('functionResponse' in part && part.functionResponse),
+    );
+
+    if (textParts.length > 0) {
+      result.push({ ...content, parts: textParts });
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary

- Fix classifier router 400 errors caused by mismatched functionCall/functionResponse counts when Gemini API returns functionCall parts without `id` fields
- Improve `deduplicateFunctionResponses` to use `id || name` as dedup key for functionResponse parts
- Strip all functionCall/functionResponse parts from history before sending to NumericalClassifierStrategy — the classifier only needs text for complexity scoring

## Root Cause

The Gemini API returns `functionCall` parts with only `name` + `args` (no `id`).  The dedup logic in `geminiChat.ts` relied solely on `id` for matching, so id-less parts were silently skipped.  This left orphaned functionCalls in the history, causing `"Please ensure that the number of function response parts is equal to the number of function call parts"` 400 errors when the classifier router forwarded the history to the API.

Two specific scenarios:
1. `gemini_web_search` functionCall with no corresponding functionResponse (replaced by `"System: Please continue."` text)
2. `activate_skill` functionCall whose response is injected as llmContent text, not a standard functionResponse

## Changes

| File | Change |
|------|--------|
| `geminiChat.ts` | Use `id \|\| name` as dedup key in Pass 1; keep Pass 2 orphan removal id-only (conservative) |
| `numericalClassifierStrategy.ts` | Add `stripFunctionParts()` to remove all tool-call parts from classifier history |
| `numericalClassifierStrategy.test.ts` | Update test to verify function parts are stripped |

## Test plan

- [x] `geminiChat.test.ts` — 48/48 passed
- [x] `numericalClassifierStrategy.test.ts` — 22/22 passed
- [ ] Manual: verify classifier router no longer triggers 400 on conversations with tool calls