### PR TITLE
fix(core): prevent false InvalidStreamError for thinking models

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -622,14 +622,10 @@ describe('GeminiChat', () => {
         LlmRole.MAIN,
       );
 
-      // 4. Assert: The stream processing should throw an InvalidStreamError.
-      await expect(
-        (async () => {
-          for await (const _ of stream) {
-            // This loop consumes the stream to trigger the internal logic.
-          }
-        })(),
-      ).rejects.toThrow(InvalidStreamError);
+      // 4. Assert: Thought-only responses are valid — should NOT throw.
+      for await (const _ of stream) {
+        // consume stream
+      }
     });
 
     it('should succeed when there is a tool call without finish reason', async () => {
@@ -714,9 +710,10 @@ describe('GeminiChat', () => {
       ).rejects.toThrow(InvalidStreamError);
     });
 
-    it('should throw InvalidStreamError when no tool call and empty response text', async () => {
+    it('should NOT throw InvalidStreamError when response has only thought content', async () => {
       // Setup: Stream with finish reason but empty response (only thoughts)
-      const streamWithEmptyResponse = (async function* () {
+      // Thinking models may produce only thoughts — this is valid.
+      const streamWithThoughtOnly = (async function* () {
         yield {
           candidates: [
             {
@@ -731,7 +728,7 @@ describe('GeminiChat', () => {
       })();
 
       vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
-        streamWithEmptyResponse,
+        streamWithThoughtOnly,
       );
 
       const stream = await chat.sendMessageStream(
@@ -742,13 +739,10 @@ describe('GeminiChat', () => {
         LlmRole.MAIN,
       );
 
-      await expect(
-        (async () => {
-          for await (const _ of stream) {
-            // consume stream
-          }
-        })(),
-      ).rejects.toThrow(InvalidStreamError);
+      // Thought-only responses are valid — should NOT throw.
+      for await (const _ of stream) {
+        // consume stream
+      }
     });
 
     it('should succeed when there is finish reason and response text', async () => {
@@ -1064,8 +1058,8 @@ describe('GeminiChat', () => {
   });
 
   describe('sendMessageStream with retries', () => {
-    it('should not retry on invalid content if model does not start with gemini-2', async () => {
-      // Mock the stream to fail.
+    it('should retry on invalid content regardless of model name', async () => {
+      // InvalidStreamError retry now applies to all models, not just gemini-2.x.
       vi.mocked(mockContentGenerator.generateContentStream).mockImplementation(
         async () =>
           (async function* () {
@@ -1091,11 +1085,11 @@ describe('GeminiChat', () => {
         })(),
       ).rejects.toThrow(InvalidStreamError);
 
-      // Should be called only 1 time (no retry)
+      // Should be called 2 times (1 initial + 1 retry)
       expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
-        1,
+        2,
       );
-      expect(mockLogContentRetry).not.toHaveBeenCalled();
+      expect(mockLogContentRetry).toHaveBeenCalled();
     });
 
     it('should yield a RETRY event when an invalid stream is encountered', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -25,11 +25,7 @@ import {
 } from '../utils/retry.js';
 import type { ValidationRequiredError } from '../utils/googleQuotaErrors.js';
 import type { Config } from '../config/config.js';
-import {
-  resolveModel,
-  isGemini2Model,
-  supportsModernFeatures,
-} from '../config/models.js';
+import { resolveModel, supportsModernFeatures } from '../config/models.js';
 import { hasCycleInSchema } from '../tools/tools.js';
 import type { StructuredError } from './turn.js';
 import type { CompletedToolCall } from './coreToolScheduler.js';
@@ -415,10 +411,7 @@ export class GeminiChat {
             lastError = error;
             const isContentError = error instanceof InvalidStreamError;
 
-            if (
-              (isContentError && isGemini2Model(model)) ||
-              (isRetryable && !signal.aborted)
-            ) {
+            if (isContentError || (isRetryable && !signal.aborted)) {
               // Check if we have more attempts left.
               if (attempt < maxAttempts - 1) {
                 const delayMs = INVALID_CONTENT_RETRY_OPTIONS.initialDelayMs;
@@ -446,10 +439,7 @@ export class GeminiChat {
         }
 
         if (lastError) {
-          if (
-            lastError instanceof InvalidStreamError &&
-            isGemini2Model(model)
-          ) {
+          if (lastError instanceof InvalidStreamError) {
             logContentRetryFailure(
               this.config,
               new ContentRetryFailureEvent(maxAttempts, lastError.type, model),
@@ -914,6 +904,7 @@ export class GeminiChat {
     const modelResponseParts: Part[] = [];
 
     let hasToolCall = false;
+    let hasThought = false;
     let finishReason: FinishReason | undefined;
 
     for await (const chunk of streamResponse) {
@@ -929,6 +920,7 @@ export class GeminiChat {
         const content = chunk.candidates?.[0]?.content;
         if (content?.parts) {
           if (content.parts.some((part) => part.thought)) {
+            hasThought = true;
             // Record thoughts
             this.recordThoughtFromContent(content);
           }
@@ -1012,13 +1004,15 @@ export class GeminiChat {
     // Stream validation logic: A stream is considered successful if:
     // 1. There's a tool call OR
     // 2. There's inline data (image generation models like nano-banana-pro) OR
-    // 3. A not MALFORMED_FUNCTION_CALL finish reason and a non-empty response text
+    // 3. There's thought content (thinking models may produce only thoughts) OR
+    // 4. A not MALFORMED_FUNCTION_CALL finish reason and a non-empty response text
     //
-    // We throw an error only when there's no tool call AND no inline data AND:
+    // We throw an error only when there's no tool call AND no inline data
+    // AND no thought content AND:
     // - No finish reason, OR
     // - MALFORMED_FUNCTION_CALL finish reason OR
-    // - Empty response text (e.g., only thoughts with no actual content)
-    if (!hasToolCall && !hasInlineData) {
+    // - Empty response text
+    if (!hasToolCall && !hasInlineData && !hasThought) {
       if (!finishReason) {
         throw new InvalidStreamError(
           'Model stream ended without a finish reason.',


### PR DESCRIPTION
## Summary

- **Track thought-only responses**: Thinking models (gemini-2.5-flash/pro) can produce streams with only `thought=true` parts. These were being filtered out before validation, causing false `NO_RESPONSE_TEXT` errors and cascading `InvalidStreamError` retries.
- **Remove `isGemini2Model` gate on retry**: InvalidStream retry was gated to only `gemini-2.x` models. This is now enabled for all models since the issue is not model-family-specific.
- **Tests updated**: Three test cases updated to reflect new behavior (thought-only streams are valid, retry applies to all models).

## Root Cause

Sentry ELECTRON-VS (issue 113336133): "Invalid response stream detected after multiple retries"

`processStreamResponse` in `geminiChat.ts` filters out `part.thought=true` parts before checking `hasText`. For thinking models that produce thought-only responses (no user-visible text), this results in `hasText=false` → `NO_RESPONSE_TEXT` → `InvalidStreamError`. The error then cascades through retry layers, consuming quota.

## Changes

- `geminiChat.ts`: Added `hasThought` tracking; treat thought-only responses as valid
- `geminiChat.ts`: Removed `isGemini2Model` condition from retry logic
- `geminiChat.test.ts`: Updated 3 tests to match new behavior

## Test plan

- [x] `bun test geminiChat.test.ts` — all tests pass
- [x] Verified thought-only stream no longer triggers InvalidStreamError
- [x] Verified non-gemini-2 models now get InvalidStream retry